### PR TITLE
add support for requestor authentication

### DIFF
--- a/waar/config.yaml
+++ b/waar/config.yaml
@@ -1,6 +1,8 @@
 url: http://localhost:8080
 bindAddr: :8080
 irmaServerURL: http://localhost:8088
+#signingKey: sk.pem
+#requestor: irma-welkom
 
 dbDriver: mysql
 dbHost: localhost

--- a/waar/config.yaml
+++ b/waar/config.yaml
@@ -1,8 +1,7 @@
 url: http://localhost:8080
 bindAddr: :8080
 irmaServerURL: http://localhost:8088
-#signingKey: sk.pem
-#requestor: irma-welkom
+requestorToken: 1234 
 
 dbDriver: mysql
 dbHost: localhost

--- a/waar/go.mod
+++ b/waar/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/bwesterb/go-atum v1.1.2 // indirect
 	github.com/bwesterb/go-xmssmt v1.4.1 // indirect
 	github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fxamacker/cbor v1.5.1 // indirect
 	github.com/getsentry/raven-go v0.2.0 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect

--- a/waar/go.mod
+++ b/waar/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/bwesterb/go-atum v1.1.2 // indirect
 	github.com/bwesterb/go-xmssmt v1.4.1 // indirect
 	github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894 // indirect
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fxamacker/cbor v1.5.1 // indirect
 	github.com/getsentry/raven-go v0.2.0 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect


### PR DESCRIPTION
Make sure the requestor/requestor signing key is in the configuration. Also make sure that the associated public key is in the configuration of the admin IRMA server.